### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -1,5 +1,7 @@
 name: GitHub Actions Demo
 run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
+permissions:
+  contents: read
 on: [push]
 jobs:
   Explore-GitHub-Actions:


### PR DESCRIPTION
Potential fix for [https://github.com/Alcheri/MyDNS/security/code-scanning/2](https://github.com/Alcheri/MyDNS/security/code-scanning/2)

In general, the fix is to explicitly declare a `permissions` block that restricts the `GITHUB_TOKEN` to the minimal scopes required. Since this workflow only checks out the repository and reads files, it only needs read access to repository contents. We can safely add `permissions: contents: read` at the workflow root so it applies to all jobs, without changing functionality.

The best targeted fix here is:
- Add a top-level `permissions` section after the `run-name` (or after `name`) in `.github/workflows/github-actions-demo.yml`.
- Set `contents: read` as the only permission, which is sufficient for `actions/checkout@v4` and the read-only shell commands used in the job.
- No other files or imports are needed; no job-level overrides are required since there is only one job and it doesn’t need write access.

Concretely, modify `.github/workflows/github-actions-demo.yml` to insert:

```yml
permissions:
  contents: read
```

between `run-name:` and `on:`. No other changes are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
